### PR TITLE
let other package correctly find mano file path

### DIFF
--- a/manotorch/manolayer.py
+++ b/manotorch/manolayer.py
@@ -67,6 +67,9 @@ class ManoLayer(torch.nn.Module):
 
         # load model according to side flag
         mano_assets_path = os.path.join(mano_assets_root, "models", f"MANO_{side.upper()}.pkl")  # eg.  MANO_RIGHT.pkl
+        # get the path of current folder
+        current_folder = os.path.dirname(os.path.abspath(__file__))
+        mano_assets_path = current_folder + "/../" + mano_assets_path
         assert os.path.isfile(
             mano_assets_path), f"Can not find MANO assets {mano_assets_path}, please follow steps in README.md"
 


### PR DESCRIPTION
mano_assets_path was guided to put in this repo, so we need to give abs path to let other package find it